### PR TITLE
Instagram filter alyosama

### DIFF
--- a/InstagramFilterPlugin/src/DkInstagramPlugin.cpp
+++ b/InstagramFilterPlugin/src/DkInstagramPlugin.cpp
@@ -152,10 +152,10 @@ QSharedPointer<nmc::DkImageContainer> DkInstagramPlugin::runPlugin(const QString
 QImage DkInstagramPlugin::applyImageFilter(const QImage inImg){
 #ifdef WITH_OPENCV
 	int MAX_KERNEL_LENGTH = 31;
-	cv::Mat src = DkInstagramPlugin::qImage2Mat(inImg);
+	cv::Mat src =  DkImage::qImage2Mat(inImg);
 	cv::Mat dst;
 	DkInstagramPlugin::nashville(src,dst);
-	return (DkInstagramPlugin::mat2QImage(dst));
+	return (DkImage::mat2QImage(dst));
 #else
 	return inImg;
 #endif
@@ -171,13 +171,13 @@ void DkInstagramPlugin::nashville(const Mat& src, Mat& dst)
 {
 
     dst.create(src.size(), src.type());
-    vector<Mat> channel(3);
+    std::vector<Mat> channel(3);
     split(src, channel);
 
     //Approximated values for Nashville instagram filter
     int mappoint_bgr[3][16]=
-    {{23,41,63,87,115,139,163,185,204,219,230,238,244,247,250,252},
-    {4,10,20,34,52,73,94,117,139,157,177,192,204,214,223,229},
+    {{4,10,20,34,52,73,94,117,139,157,177,192,204,214,223,229},
+    {23,41,63,87,115,139,163,185,204,219,230,238,244,247,250,252},
     {41,48,57,65,72,79,86,91,96,104,109,115,122,132,143,154}};
 
     for( int c = 0; c < 3; c++ ){
@@ -189,7 +189,10 @@ void DkInstagramPlugin::nashville(const Mat& src, Mat& dst)
                 float t = (i%16)/16.0;
                 uchar a=mappoint_bgr[c][i/16];
                 uchar b=mappoint_bgr[c][i/16+1];
-                channel[c].at<uchar>(y,x)= a+t*(b-a);
+          		uchar newColor=a+t*(b-a);
+          		if(newColor<0)newColor=0;
+          		else if(newColor>255)newColor=255;
+                channel[c].at<uchar>(y,x)= newColor;
             }
         }
     }

--- a/InstagramFilterPlugin/src/DkInstagramPlugin.cpp
+++ b/InstagramFilterPlugin/src/DkInstagramPlugin.cpp
@@ -152,8 +152,8 @@ QSharedPointer<nmc::DkImageContainer> DkInstagramPlugin::runPlugin(const QString
 QImage DkInstagramPlugin::applyImageFilter(const QImage inImg){
 #ifdef WITH_OPENCV
 	int MAX_KERNEL_LENGTH = 31;
-	cv::Mat src =  DkImage::qImage2Mat(inImg);
-	cv::Mat dst;
+	Mat src =  DkImage::qImage2Mat(inImg);
+	Mat dst;
 	DkInstagramPlugin::nashville(src,dst);
 	return (DkImage::mat2QImage(dst));
 #else
@@ -175,7 +175,7 @@ void DkInstagramPlugin::nashville(const Mat& src, Mat& dst)
     split(src, channel);
 
     //Approximated values for Nashville instagram filter
-    int mappoint_bgr[3][16]=
+    uchar mappoint_bgr[3][16]=
     {{4,10,20,34,52,73,94,117,139,157,177,192,204,214,223,229},
     {23,41,63,87,115,139,163,185,204,219,230,238,244,247,250,252},
     {41,48,57,65,72,79,86,91,96,104,109,115,122,132,143,154}};
@@ -185,14 +185,14 @@ void DkInstagramPlugin::nashville(const Mat& src, Mat& dst)
             for( int x = 0; x < src.cols; x++ ){
 
                 // Compute new color Value from mappoint_bgr 
-                uchar i =channel[c].at<uchar>(y,x);
+				uchar i =channel[c].at<uchar>(y,x);
                 float t = (i%16)/16.0;
                 uchar a=mappoint_bgr[c][i/16];
                 uchar b=mappoint_bgr[c][i/16+1];
-          		uchar newColor=a+t*(b-a);
-          		if(newColor<0)newColor=0;
-          		else if(newColor>255)newColor=255;
-                channel[c].at<uchar>(y,x)= newColor;
+          		float newColor=a+t*(b-a);
+          		if(newColor<0)newColor=0.0f;
+          		else if(newColor>255.0f)newColor=255.0f;
+                channel[c].at<uchar>(y,x)= (uchar)qRound(newColor);
             }
         }
     }

--- a/InstagramFilterPlugin/src/DkInstagramPlugin.h
+++ b/InstagramFilterPlugin/src/DkInstagramPlugin.h
@@ -35,6 +35,7 @@
 
 
 #include "DkPluginInterface.h"
+#include "DkImageStorage.h"
 
 // OpenCV
 #ifdef WITH_OPENCV
@@ -72,8 +73,6 @@ public:
 
 	enum {
 		ID_ACTION1,
-		// add actions here
-
 		id_end
 	};
 
@@ -85,73 +84,7 @@ protected:
 	QStringList mMenuStatusTips;
 
 #ifdef WITH_OPENCV
-
 	static void nashville(const Mat& myImage, Mat& Result);
-/**
-	 * Converts a QImage to a Mat
-	 * @param img formats supported: ARGB32 | RGB32 | RGB888 | Indexed8
-	 * @return cv::Mat the corresponding Mat
-	 **/ 
-	static Mat qImage2Mat(const QImage img) {
-
-		Mat mat2;
-		QImage cImg;	// must be initialized here!	(otherwise the data is lost before clone())
-
-		if (img.format() == QImage::Format_ARGB32 || img.format() == QImage::Format_RGB32 ) {
-			mat2 = Mat(img.height(), img.width(), CV_8UC4, (uchar*)img.bits(), img.bytesPerLine());
-			//qDebug() << "ARGB32 or RGB32";
-		}
-		else if (img.format() == QImage::Format_RGB888) {
-			mat2 = Mat(img.height(), img.width(), CV_8UC3, (uchar*)img.bits(), img.bytesPerLine());
-			//qDebug() << "RGB888";
-		}
-		else if (img.format() == QImage::Format_Indexed8) {
-			mat2 = Mat(img.height(), img.width(), CV_8UC1, (uchar*)img.bits(), img.bytesPerLine());
-			//qDebug() << "indexed...";
-		}
-		else {
-			//qDebug() << "image flag: " << img.format();
-			cImg = img.convertToFormat(QImage::Format_ARGB32);
-			mat2 = Mat(cImg.height(), cImg.width(), CV_8UC4, (uchar*)cImg.bits(), cImg.bytesPerLine());
-			//qDebug() << "I need to convert the QImage to ARGB32";
-		}
-
-		mat2 = mat2.clone();	// we need to own the pointer
-
-		return mat2; 
-	}
-	/**
-	 * Converts a cv::Mat to a QImage.
-	 * @param img supported formats CV8UC1 | CV_8UC3 | CV_8UC4
-	 * @return QImage the corresponding QImage
-	 **/ 
-	static QImage mat2QImage(Mat img) {
-
-		QImage qImg;
-
-		// since Mat header is copied, a new buffer should be allocated (check this!)
-		if (img.depth() == CV_32F)
-			img.convertTo(img, CV_8U, 255);
-
-		if (img.type() == CV_8UC1) {
-			qImg = QImage(img.data, (int)img.cols, (int)img.rows, (int)img.step, QImage::Format_Indexed8);	// opencv uses size_t if for scaling in x64 applications
-			//Mat tmp;
-			//cvtColor(img, tmp, CV_GRAY2RGB);	// Qt does not support writing to index8 images
-			//img = tmp;
-		}
-		if (img.type() == CV_8UC3) {
-			
-			//cv::cvtColor(img, img, CV_RGB2BGR);
-			qImg = QImage(img.data, (int)img.cols, (int)img.rows, (int)img.step, QImage::Format_RGB888);
-		}
-		if (img.type() == CV_8UC4) {
-			qImg = QImage(img.data, (int)img.cols, (int)img.rows, (int)img.step, QImage::Format_ARGB32);
-		}
-
-		qImg = qImg.copy();
-
-		return qImg;
-	}
 #endif
 
 


### PR DESCRIPTION
1. I have removed "cv" namespace  but have added "std" for vector due to some compiling problems with some machines
2. I have solved the overflow problems with white pixels and tested it on Lena image.
3. I have removed qImage2Mat and mat2QImage and using them from "DkImage" class

Note: I wanted also to remove qImage2Mat and mat2QImage from "FakeMiniaturesPlugin" but there was a problem when i include "DkImageStorage.h", I think there is circular dependences problem.So I hope i will fix this later. 
