### PR TITLE
PatchMatchingPlugin - improved point placement (snaps to nearest clone)

### DIFF
--- a/AffineTransformations/src/DkAffineTransformationsPlugin.json
+++ b/AffineTransformations/src/DkAffineTransformationsPlugin.json
@@ -3,7 +3,7 @@
 	"AuthorName" 	: "Tim Jerman",
 	"Company"		: "",
 	"DateCreated" 	: "2014-06-01",
-	"DateModified"	: "2016-07-13",
+	"DateModified"	: "2016-07-22",
 	"Description"	: "Apply affine transformations to the selected image. The available transformations are: scale, rotation (with automatic skewness detection), and shear.",
 	"Tagline" 	: "Transform and rotate images",
 	"PluginId"		: "7a4a50a45ddb408ba46a16a40e6518fd",

--- a/FakeMiniaturesPlugin/src/DkFakeMiniaturesPlugin.json
+++ b/FakeMiniaturesPlugin/src/DkFakeMiniaturesPlugin.json
@@ -3,7 +3,7 @@
 	"AuthorName" 	: "Tim Jerman",
 	"Company"		: "",
 	"DateCreated" 	: "2014-06-01",
-	"DateModified"	: "2016-07-13",
+	"DateModified"	: "2016-07-22",
 	"Description"	: "On the preview image select (by mouse click move and release) the region without blurring. A blur is applyied depending on the distance from this region. The amount of blur and saturation can be changed with the sliders on the right of the dialog.",
 	"Tagline" 		: "Apply a fake miniature filter (tilt shift effect) to the image.",
 	"PluginId"		: "a2ac7b68866b4ab29fb1df3e170b8f0d",

--- a/PageExtractionPlugin/src/DkPageExtractionPlugin.json
+++ b/PageExtractionPlugin/src/DkPageExtractionPlugin.json
@@ -3,7 +3,7 @@
 	"AuthorName" 	: "Markus Diem",
 	"Company"		: "Computer Vision Lab",
 	"DateCreated" 	: "2015-08-27",
-	"DateModified"	: "2016-07-13",
+	"DateModified"	: "2016-07-22",
 	"Description"	: "This plugin detects document pages and either crops the image accordingly or annotates the region.",
 	"Tagline" 		: "Detect document pages in images",
 	"PluginId"		: "4acb88c461024cb080ae5cd15d0ef0ec",

--- a/PaintPlugin/src/DkPaintPlugin.json
+++ b/PaintPlugin/src/DkPaintPlugin.json
@@ -3,7 +3,7 @@
 	"AuthorName" 	: "Tim Jerman",
 	"Company"		: "",
 	"DateCreated" 	: "2014-05-01",
-	"DateModified"	: "2016-07-13",
+	"DateModified"	: "2016-07-22",
 	"Description"	: "Paint on an image. The color, size and opacity of the brush can be changed.",
 	"Tagline" 		: "Draw with adjustable brushes to an image.",
 	"PluginId"		: "ad970ef36cc24737afd2b53ad015ff0d",

--- a/PatchMatchingPlugin/src/DkPatchMatchingPlugin.cpp
+++ b/PatchMatchingPlugin/src/DkPatchMatchingPlugin.cpp
@@ -346,29 +346,29 @@ namespace nmp {
 
 			auto nearest_poly = firstPoly();
 			QPointF startDiff;
-			for (auto r : mRenderer) {
-				auto poly_points = r->getPolygon()->points();
-				auto first = unmapToViewPort(r, poly_points.first()->getPos());
-				auto last = unmapToViewPort(r, poly_points.last()->getPos());
-				if (startDiff.isNull()) {
-					startDiff = first - point;
-				}
 
-				auto first_diff = first - point;
-				auto last_diff = last - point;
-				if (qAbs(first_diff.manhattanLength()) < qAbs(startDiff.manhattanLength())) {
-					startDiff = first_diff;
-					nearest_poly = r;
-				}
-				if (qAbs(last_diff.manhattanLength()) < qAbs(startDiff.manhattanLength())) {
-					startDiff = last_diff;
-					nearest_poly = r;
+			if (!currentPolygon()->points().isEmpty()) {
+				for (auto r : mRenderer) {
+					auto poly_points = r->getPolygon()->points();
+					auto first = unmapToViewPort(r, poly_points.first()->getPos());
+					auto last = unmapToViewPort(r, poly_points.last()->getPos());
+					if (startDiff.isNull()) {
+						startDiff = first - point;
+					}
+
+					auto first_diff = first - point;
+					auto last_diff = last - point;
+					if (qAbs(first_diff.manhattanLength()) < qAbs(startDiff.manhattanLength())) {
+						startDiff = first_diff;
+						nearest_poly = r;
+					}
+					if (qAbs(last_diff.manhattanLength()) < qAbs(startDiff.manhattanLength())) {
+						startDiff = last_diff;
+						nearest_poly = r;
+					}
 				}
 			}
-
-			//(getTransform()*getWorldMatrix()).inverted().map(pos)
-
-			//std::cout << "Nearest Poly: " << nearest_poly->getColor().name << std::endl;
+			
 			nearest_poly->addPointMouseCoords(point);
 		}
 	}

--- a/PatchMatchingPlugin/src/DkPatchMatchingPlugin.cpp
+++ b/PatchMatchingPlugin/src/DkPatchMatchingPlugin.cpp
@@ -356,7 +356,7 @@ namespace nmp {
 						startDiff = first - point;
 					}
 
-					auto first_diff = first - point;
+					auto first_diff = last - point;
 					auto last_diff = last - point;
 					if (qAbs(first_diff.manhattanLength()) < qAbs(startDiff.manhattanLength())) {
 						startDiff = first_diff;
@@ -674,7 +674,7 @@ namespace nmp {
 	{
 		auto text = "Polygon";
 		mPolygonCombobox->addItem(text);
-		qDebug() << "COunt = " << mPolygonCombobox->count();
+		qDebug() << "Count = " << mPolygonCombobox->count();
 		mPolygonCombobox->setItemData(mPolygonCombobox->count() - 1, color, Qt::BackgroundRole);
 		if (select) {
 			mPolygonCombobox->setCurrentIndex(mPolygonCombobox->count() - 1);

--- a/PatchMatchingPlugin/src/DkPatchMatchingPlugin.cpp
+++ b/PatchMatchingPlugin/src/DkPatchMatchingPlugin.cpp
@@ -24,7 +24,6 @@
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
  *******************************************************************************************************/
-#include <iostream> // For Testing
 
 #include "DkPatchMatchingPlugin.h"
 
@@ -169,7 +168,6 @@ namespace nmp {
 
 	void DkPatchMatchingViewPort::loadFromFile()
 	{
-
 		clear();
 
 		QFile file{ getJsonFilePath() };
@@ -262,7 +260,6 @@ namespace nmp {
 		auto poly = addClone(currentPolygon());
 		poly->translate(400, 0);
 
-		//updateInactive();
 		update();
 		updateInactive();
 
@@ -309,8 +306,6 @@ namespace nmp {
 
 	void DkPatchMatchingViewPort::saveToFile()
 	{
-	
-
 		// write to file
 		QFile saveFile(getJsonFilePath());
 
@@ -323,7 +318,6 @@ namespace nmp {
 		saveFile.write(mCurrentFile);
 
 		qDebug() << "[PatchMatchingPlugin] Saving file : Success!!!";
-
 	}
 
 	auto unmapToViewPort(QSharedPointer<nmp::DkPolygonRenderer> poly, QPointF point) {
@@ -331,10 +325,13 @@ namespace nmp {
 	}
 
 	auto DkPatchMatchingViewPort::getNearestPolygon(QPointF point) {
+		// First Point is default polygon
 		auto polygon = firstPoly();
+
 		if (!currentPolygon()->points().isEmpty()) {
-			auto startDiff = QLineF(currentPolygon()->points().first()->getPos(), point).length();	// Set Start Difference to First Point of the current Polygon
+			auto startDiff = QLineF(currentPolygon()->points().first()->getPos(), point).length();	// Set Start Difference from first to point of the current Polygon
 			for (auto r : mRenderer) {
+				// Only on active polygon
 				if (!r->isInactive()) {
 					auto poly_points = r->getPolygon()->points();
 					auto first = unmapToViewPort(r, poly_points.first()->getPos());
@@ -358,7 +355,6 @@ namespace nmp {
 	}
 
 	void DkPatchMatchingViewPort::mousePressEvent(QMouseEvent *event) {
-
 		// panning -> redirect to viewport
 		if (event->buttons() == Qt::LeftButton &&
 			(event->modifiers() == nmc::Settings::param().global().altMod || panning)) {
@@ -371,6 +367,7 @@ namespace nmp {
 		if (event->buttons() == Qt::LeftButton && parent()) {
 			QPointF point = event->pos();
 
+			// Get nearest polygon to point
 			auto nearest_poly = getNearestPolygon(point);
 			nearest_poly->addPointMouseCoords(point);
 		}

--- a/PatchMatchingPlugin/src/DkPatchMatchingPlugin.h
+++ b/PatchMatchingPlugin/src/DkPatchMatchingPlugin.h
@@ -100,6 +100,8 @@ public:
 	void checkWorldMatrixChanged();
 	QByteArray createCurrentJson();
 
+	auto getNearestPolygon(QPointF point);
+
 public slots:
 	void setVisible(bool visible) override;
 	void updateImageContainer(QSharedPointer<nmc::DkImageContainerT> imgC) override;

--- a/PatchMatchingPlugin/src/DkPatchMatchingPlugin.json
+++ b/PatchMatchingPlugin/src/DkPatchMatchingPlugin.json
@@ -3,7 +3,7 @@
 	"AuthorName" 	: "Manuel",
 	"Company"		: "",
 	"DateCreated" 	: "2014-05-01",
-	"DateModified"	: "2016-05-10",
+	"DateModified"	: "2016-07-22",
 	"Description"	: "Stuff",
 	"Tagline" 		: "Stuff.",
 	"PluginId"		: "ccbf6ff1f8ab4da5a8c44269c81ebf8b",

--- a/PatchMatchingPlugin/src/DkPatchMatchingPlugin.json
+++ b/PatchMatchingPlugin/src/DkPatchMatchingPlugin.json
@@ -3,7 +3,7 @@
 	"AuthorName" 	: "Manuel",
 	"Company"		: "",
 	"DateCreated" 	: "2014-05-01",
-	"DateModified"	: "2016-07-22",
+	"DateModified"	: "2016-07-26",
 	"Description"	: "Stuff",
 	"Tagline" 		: "Stuff.",
 	"PluginId"		: "ccbf6ff1f8ab4da5a8c44269c81ebf8b",

--- a/PatchMatchingPlugin/src/DkPolyTimeline.cpp
+++ b/PatchMatchingPlugin/src/DkPolyTimeline.cpp
@@ -107,9 +107,7 @@ namespace nmp {
 		mSize(40),
 		mLayout(nullptr)
 	{
-		qDebug() << "Inside PolyTimeLine Constructor";
 		QWidget* c = new QWidget(this);
-		qDebug() << "QWidget: " << c->frameSize().rheight() << "/" << c->frameSize().rwidth();
 		mLayout = new QGridLayout(c);
 		mLayout->setAlignment(Qt::AlignLeft | Qt::AlignVCenter);
 
@@ -126,7 +124,6 @@ namespace nmp {
 		l->addWidget(mScrollArea);
 		
 		setSyncedPolygon(poly); 
-		qDebug() << "End of PolyTimeLine Constructor";
 	}
 
 

--- a/PatchMatchingPlugin/src/DkPolyTimeline.cpp
+++ b/PatchMatchingPlugin/src/DkPolyTimeline.cpp
@@ -107,7 +107,9 @@ namespace nmp {
 		mSize(40),
 		mLayout(nullptr)
 	{
+		qDebug() << "Inside PolyTimeLine Constructor";
 		QWidget* c = new QWidget(this);
+		qDebug() << "QWidget: " << c->frameSize().rheight() << "/" << c->frameSize().rwidth();
 		mLayout = new QGridLayout(c);
 		mLayout->setAlignment(Qt::AlignLeft | Qt::AlignVCenter);
 
@@ -124,6 +126,7 @@ namespace nmp {
 		l->addWidget(mScrollArea);
 		
 		setSyncedPolygon(poly); 
+		qDebug() << "End of PolyTimeLine Constructor";
 	}
 
 

--- a/PatchMatchingPlugin/src/DkSyncedPolygon.cpp
+++ b/PatchMatchingPlugin/src/DkSyncedPolygon.cpp
@@ -7,8 +7,6 @@
 #include <tuple>
 #include <QJsonArray>
 
-#include <iostream> // For Testing
-
 namespace {
 	// calculate distance to given line
 	// additionally return true if the point can be mapped onto the line segment (not outside)
@@ -164,7 +162,6 @@ namespace nmp {
 
 	void DkSyncedPolygon::addPoint(const QPointF & coordinates)
 	{
-		//std::cout << "Added with DkSyncedPolygon" << std::endl;
 		auto coords = coordinates;
 		// map to image rect
 		//mapToImageRect(coords);	// returns false if point should be discarded
@@ -192,7 +189,7 @@ namespace nmp {
 		connect(point.data(), &DkControlPoint::moved, this, &DkSyncedPolygon::movedPoint);
 			
 		// insert, default is end() so this works too
-		if (mControlPoints.insert(insert, point)+1 == mControlPoints.end() || toFirstPt) {
+		if (mControlPoints.insert(insert, point)+1 == mControlPoints.end()) {
 			emit pointAdded(point);		// just point added			
 		}
 		else {
@@ -395,20 +392,15 @@ namespace nmp {
 		//counter++;
 		//std::cout << "Added with DkPolygonRenderer " << counter << std::endl;
 
-		auto prev = mPolygon->points().indexOf(point);
+		auto prev = mPolygon->points().indexOf(point) - 1;
+		qDebug() << prev;
 
 		// add line if necessary
-		if (prev > 0) {
-			auto pair = std::make_pair(mPolygon->points()[prev-1], point);
+		if (prev >= 0) {
+			auto pair = std::make_pair(mPolygon->points()[prev], point);
 			auto line = new DkLineRepresentation(pair, getViewport());
 			line->setVisible(true);
 			mLines.append(line);
-		}
-		else if (prev == 0){
-			auto pair = std::make_pair(mPolygon->points()[prev+1], point);
-			auto line = new DkLineRepresentation(pair, getViewport());
-			line->setVisible(true);
-			mLines.prepend(line);
 		}
 
 		// add point
@@ -419,12 +411,12 @@ namespace nmp {
 		connect(rep, &DkControlPointRepresentation::rotated, this, &DkPolygonRenderer::rotate);
 		rep->setVisible(true);
 
-		if (prev == 0) {
-			mPoints.prepend(rep);
-		}
-		else {
+		//if (prev == 0) {
+		//	mPoints.prepend(rep);
+		//}
+		//else {
 			mPoints.append(rep);
-		}
+		//}
 
 		update();
 	}

--- a/PatchMatchingPlugin/src/DkSyncedPolygon.cpp
+++ b/PatchMatchingPlugin/src/DkSyncedPolygon.cpp
@@ -393,7 +393,6 @@ namespace nmp {
 		//std::cout << "Added with DkPolygonRenderer " << counter << std::endl;
 
 		auto prev = mPolygon->points().indexOf(point) - 1;
-		qDebug() << prev;
 
 		// add line if necessary
 		if (prev >= 0) {

--- a/PatchMatchingPlugin/src/DkSyncedPolygon.cpp
+++ b/PatchMatchingPlugin/src/DkSyncedPolygon.cpp
@@ -577,6 +577,7 @@ namespace nmp {
 				*lastAngle = angle;
 			};
 		}
+
 		else if (event->button() ==  Qt::LeftButton) {
 
 			auto posGrab = mRenderer->mapToViewport(mapToParent(event->pos()));

--- a/PatchMatchingPlugin/src/DkSyncedPolygon.h
+++ b/PatchMatchingPlugin/src/DkSyncedPolygon.h
@@ -80,7 +80,7 @@ namespace nmp {
 		// if transform is provided, the bounding box of the mapped points
 		// is calculated
 		QRectF boundingRect(QTransform transform = QTransform{}) const;
-		
+
 		// center of the bounding box (not center of gravity)
 		QPointF center() const;
 
@@ -94,6 +94,9 @@ namespace nmp {
 		void setInactive(bool inactive);
 		bool isInactive() const;
 
+		// Get the default point to append
+		auto getDefaultPoint(QPointF point);
+
 	signals:
 		// point is added @ the end
 		void pointAdded(QSharedPointer<DkControlPoint> point);
@@ -103,18 +106,18 @@ namespace nmp {
 
 		// structural changes (i.e., point inserted in the middle or removed)
 		void changed();
-		
+
 		// one control point moved
 		void movedPoint();
 
-	public slots:
+		public slots:
 		// removes the given control point  from the polygon
 		void removePoint(QSharedPointer<DkControlPoint> point);
 
 	private:
 		// checks if this function is near any edge of the polygon
 		// if yes, moves point to this point
-		auto mapToNearestLine(QPointF& point);
+		auto mapToNearestLine(QPointF& point, QSharedPointer<nmp::DkControlPoint>* default_pt);
 
 		QVector<QSharedPointer<DkControlPoint> > mControlPoints;	// the points
 		double mSnapDistance;										// distance for mapToNearestLine

--- a/PatchMatchingPlugin/src/DkSyncedPolygon.h
+++ b/PatchMatchingPlugin/src/DkSyncedPolygon.h
@@ -168,7 +168,6 @@ namespace nmp {
 		bool isInactive() const;
 
 		QSharedPointer<DkSyncedPolygon> getPolygon();
-
 	signals:
 		// this signal is emitted whenever a transform is changed
 		// which is needed for updating stuff

--- a/ThresholdPlugin/src/DkThresholdPlugin.json
+++ b/ThresholdPlugin/src/DkThresholdPlugin.json
@@ -3,7 +3,7 @@
 	"AuthorName" 	: "Tim Jerman",
 	"Company"		: "",
 	"DateCreated" 	: "2014-06-01",
-	"DateModified"	: "2016-07-13",
+	"DateModified"	: "2016-07-22",
 	"Description"	: "Fast threshold selection for color and grayscale images. If wanted a ranged threshold can be created by changing the upper threshold value. Threshold can be applied to each of the color channels or to the luminance channel.",
 	"Tagline" 	: "Manually threshold an image.",
 	"PluginId"		: "70e2fbe0c913462e846bb91da201ceca",


### PR DESCRIPTION
- new points are assigned to the nearest clone
- in case the start point is closer the point is added @ the front instead of @ the back
- clone can be moved at any point using ALT modifier
